### PR TITLE
Optimized Cluster Distribution, Refactored Code (removed nested for loops)

### DIFF
--- a/compiler.sh
+++ b/compiler.sh
@@ -34,6 +34,7 @@ fi
 #export LIBRARY_PATH=<paths>:$LIBRARY_PATH
 #if you have custom dynamic library paths, uncomment below and export them
 #export LD_LIBRARY_PATHS=<paths>:$LD_LIBRARY_PATHS
+export NETCDF="/usr/local/include/"
 if [ -z "$NETCDF" ]
 then
     export NETCDFINC=/usr/include/openmpi-x86_64/

--- a/compiler.sh
+++ b/compiler.sh
@@ -34,7 +34,6 @@ fi
 #export LIBRARY_PATH=<paths>:$LIBRARY_PATH
 #if you have custom dynamic library paths, uncomment below and export them
 #export LD_LIBRARY_PATHS=<paths>:$LD_LIBRARY_PATHS
-export NETCDF="/usr/local/include/"
 if [ -z "$NETCDF" ]
 then
     export NETCDFINC=/usr/include/openmpi-x86_64/

--- a/src/troute-network/troute/nhd_network.py
+++ b/src/troute-network/troute/nhd_network.py
@@ -743,8 +743,6 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                     if us_depth <= stop_depth:
                         Q.extend(zip(rx, [us_depth] * len(rx)))
                 
-                # reachable: a list of reachable segments within max_depth from source node h
-                # rv[h]= reachable
                 rv[h]["reachable_nodes"] = reachable
 
             # find headwater segments in reachable groups, these will become the next set of sources
@@ -752,7 +750,6 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
             new_sources = set()
             for tw, _ in rv.items():
                 # identify downstream connections for segments in this subnetwork
-                # seg = rv[tw]
                 seg = rv[tw]["reachable_nodes"]
                 c = {key: connections[key] for key in seg}
                 # find apparent headwaters, will include new sources and actual headwaters
@@ -762,7 +759,6 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                 # append list of new sources
                 new_sources.update(srcs)
                 # remove new sources from the subnetwork list
-                # rv[tw]["reachable_nodes"].difference_update(srcs)
                 rv[tw]["reachable_nodes"].difference_update(srcs)
                 rv[tw]["connecting_nodes"] = srcs
             

--- a/src/troute-network/troute/nhd_network.py
+++ b/src/troute-network/troute/nhd_network.py
@@ -721,7 +721,8 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
             # Build dict object containing reachable nodes within max_depth from each source in new_sources
             rv = {}
             for h in new_sources:
-
+                #also include the head waters of that subnetwork in the rv dictionary
+                rv[h] = {}
                 reachable = set()
                 Q = deque([(h, 0)])
                 stop_depth = 1000000
@@ -741,15 +742,18 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
 
                     if us_depth <= stop_depth:
                         Q.extend(zip(rx, [us_depth] * len(rx)))
-
+                
                 # reachable: a list of reachable segments within max_depth from source node h
-                rv[h] = reachable
+                # rv[h]= reachable
+                rv[h]["reachable_nodes"] = reachable
 
             # find headwater segments in reachable groups, these will become the next set of sources
             # new_sources_list = []
             new_sources = set()
-            for tw, seg in rv.items():
+            for tw, _ in rv.items():
                 # identify downstream connections for segments in this subnetwork
+                # seg = rv[tw]
+                seg = rv[tw]["reachable_nodes"]
                 c = {key: connections[key] for key in seg}
                 # find apparent headwaters, will include new sources and actual headwaters
                 sub_hws = headwaters(c)
@@ -758,8 +762,10 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                 # append list of new sources
                 new_sources.update(srcs)
                 # remove new sources from the subnetwork list
-                rv[tw].difference_update(srcs)
-
+                # rv[tw]["reachable_nodes"].difference_update(srcs)
+                rv[tw]["reachable_nodes"].difference_update(srcs)
+                rv[tw]["connecting_nodes"] = srcs
+            
             # append master dictionary
             subnetworks[group_order] = rv
 

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -664,22 +664,19 @@ def compute_nhd_routing_v02(
             LOG.info("JIT Preprocessing time %s seconds." % (time.time() - start_time))
             LOG.info("starting Parallel JIT calculation")
 
-        
-            
-            # save the information of reaches_ordered_bysubntw_clustered into a csv file that has info of order, cluster, and number of segments
-            with open("Optimized_Output/reaches_ordered_bysubntw_clustered" + "_" + str(bin_threshold) + "_" + str(subnetwork_target_size) + ".csv", "w", newline="") as csvfile:
-                fieldnames = ["order", "cluster", "num_segments"]
-                writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            # # save the information of reaches_ordered_bysubntw_clustered into a csv file that has info of order, cluster, and number of segments
+            # with open("Optimized_Output/reaches_ordered_bysubntw_clustered" + "_" + str(bin_threshold) + "_" + str(subnetwork_target_size) + ".csv", "w", newline="") as csvfile:
+            #     fieldnames = ["order", "cluster", "num_segments"]
+            #     writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
 
-                writer.writeheader()
-                for order, clusters in reaches_ordered_bysubntw_clustered.items():
-                    for cluster, info in clusters.items():
-                        writer.writerow({
-                            "order": order,
-                            "cluster": cluster,
-                            "num_segments": len(info["segs"])
-                        })
-        
+            #     writer.writeheader()
+            #     for order, clusters in reaches_ordered_bysubntw_clustered.items():
+            #         for cluster, info in clusters.items():
+            #             writer.writerow({
+            #                 "order": order,
+            #                 "cluster": cluster,
+            #                 "num_segments": len(info["segs"])
+            #             })
 
         start_para_time = time.time()
         # if 1 == 1:
@@ -692,27 +689,10 @@ def compute_nhd_routing_v02(
                 for cluster, clustered_subns in reaches_ordered_bysubntw_clustered[
                     order
                 ].items():
-                    segs = clustered_subns["segs"]
-                    
-                    # offnetwork_upstreams = set()
-                    # for_loop_start_time = time.time()
-                    # segs_set = set(segs)
-                    # for seg in segs:
-                    #     for us in rconn[seg]:
-                    #         if us not in segs_set:
-                    #             offnetwork_upstreams.add(us)
-                    # for_loop_end_time = time.time()
-                    # for_loop_time += (for_loop_end_time - for_loop_start_time) 
-        
+                    segs = clustered_subns["segs"]    
                     # segs.extend(offnetwork_upstreams)                                        
                     offnetwork_upstreams = set(clustered_subns['connecting_nodes'])
                     segs.extend(offnetwork_upstreams)
-
-
-                    
-                
-                    
-
                     
                     common_segs = list(param_df.index.intersection(segs))
                     wbodies_segs = set(segs).symmetric_difference(common_segs)
@@ -949,45 +929,42 @@ def compute_nhd_routing_v02(
             )
             subnetworks_only_ordered_jit = defaultdict(dict)
             subnetworks = defaultdict(dict)
+            reaches_ordered_bysubntw = defaultdict(dict)
             for tw, ordered_network in networks_with_subnetworks_ordered_jit.items():
                 intw = independent_networks[tw]
                 for order, subnet_sets in ordered_network.items():
                     subnetworks_only_ordered_jit[order].update(subnet_sets)
                     for subn_tw, subnetwork in subnet_sets.items():
-                        subnetworks[subn_tw] = {k: intw[k] for k in subnetwork}
+                        subnetworks[subn_tw] = {k: intw[k] for k in subnetwork["reachable_nodes"]}
+                        rconn_subn = subnetworks[subn_tw]
+                        if not waterbodies_df.empty and not usgs_df.empty:
+                            path_func = partial(
+                                nhd_network.split_at_gages_waterbodies_and_junctions,
+                                set(usgs_df.index.values),
+                                set(waterbodies_df.index.values),
+                                subnetworks[subn_tw]
+                                )
 
-            reaches_ordered_bysubntw = defaultdict(dict)
-            for order, ordered_subn_dict in subnetworks_only_ordered_jit.items():
-                for subn_tw, subnet in ordered_subn_dict.items():
-                    conn_subn = {k: connections[k] for k in subnet if k in connections}
-                    rconn_subn = {k: rconn[k] for k in subnet if k in rconn}
-                    if not waterbodies_df.empty and not usgs_df.empty:
-                        path_func = partial(
-                            nhd_network.split_at_gages_waterbodies_and_junctions,
-                            set(usgs_df.index.values),
-                            set(waterbodies_df.index.values),
-                            rconn_subn
-                            )
+                        elif waterbodies_df.empty and not usgs_df.empty:
+                            path_func = partial(
+                                nhd_network.split_at_gages_and_junctions,
+                                set(usgs_df.index.values),
+                                subnetworks[subn_tw]
+                                )
 
-                    elif waterbodies_df.empty and not usgs_df.empty:
-                        path_func = partial(
-                            nhd_network.split_at_gages_and_junctions,
-                            set(usgs_df.index.values),
-                            rconn_subn
-                            )
+                        elif not waterbodies_df.empty and usgs_df.empty:
+                            path_func = partial(
+                                nhd_network.split_at_waterbodies_and_junctions,
+                                set(waterbodies_df.index.values),
+                                subnetworks[subn_tw]
+                                )
 
-                    elif not waterbodies_df.empty and usgs_df.empty:
-                        path_func = partial(
-                            nhd_network.split_at_waterbodies_and_junctions,
-                            set(waterbodies_df.index.values),
-                            rconn_subn
-                            )
+                        else:
+                            path_func = partial(nhd_network.split_at_junction, subnetworks[subn_tw])
 
-                    else:
-                        path_func = partial(nhd_network.split_at_junction, rconn_subn)
-                    reaches_ordered_bysubntw[order][
-                        subn_tw
-                    ] = nhd_network.dfs_decomposition(rconn_subn, path_func)
+                        reaches_ordered_bysubntw[order][
+                            subn_tw
+                        ] = nhd_network.dfs_decomposition(subnetworks[subn_tw], path_func)
 
             # save subnetworks_only_ordered_jit and reaches_ordered_bysubntw_clustered in a list
             # to be passed on to next loop. Create a deep copy of this list to prevent it from being
@@ -1015,6 +992,8 @@ def compute_nhd_routing_v02(
                     # TODO: Confirm that a list here is best -- we are sorting,
                     # so a set might be sufficient/better
                     segs = list(chain.from_iterable(subn_reach_list))
+                    #segs = subnetworks_only_ordered_jit[order][subn_tw]["reachable_nodes"]
+                    breakpoint()
                     offnetwork_upstreams = set()
                     segs_set = set(segs)
                     for seg in segs:

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -689,8 +689,7 @@ def compute_nhd_routing_v02(
                 for cluster, clustered_subns in reaches_ordered_bysubntw_clustered[
                     order
                 ].items():
-                    segs = clustered_subns["segs"]    
-                    # segs.extend(offnetwork_upstreams)                                        
+                    segs = list(chain.from_iterable(subn_reach_list))                                   
                     offnetwork_upstreams = set(clustered_subns['connecting_nodes'])
                     segs.extend(offnetwork_upstreams)
                     
@@ -992,17 +991,8 @@ def compute_nhd_routing_v02(
                     # TODO: Confirm that a list here is best -- we are sorting,
                     # so a set might be sufficient/better
                     segs = list(chain.from_iterable(subn_reach_list))
-                    #segs = subnetworks_only_ordered_jit[order][subn_tw]["reachable_nodes"]
-                    breakpoint()
-                    offnetwork_upstreams = set()
-                    segs_set = set(segs)
-                    for seg in segs:
-                        for us in rconn[seg]:
-                            if us not in segs_set:
-                                offnetwork_upstreams.add(us)
-
+                    offnetwork_upstreams = set(subnetworks_only_ordered_jit[order][subn_tw]["connecting_nodes"])
                     segs.extend(offnetwork_upstreams)
-                    
                     common_segs = list(param_df.index.intersection(segs))
                     wbodies_segs = set(segs).symmetric_difference(common_segs)
                     

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -15,9 +15,8 @@ import troute.routing.diffusive_utils_v02 as diff_utils
 from troute.routing.fast_reach import diffusive
 
 import logging
-import csv
 import heapq
-import pdb
+
 
 '''This is the newest version of the compute.py file, which is used to compute the routing for the NHD network.'''
 
@@ -571,8 +570,7 @@ def compute_nhd_routing_v02(
                 for order, subnet_sets in ordered_network.items():
                     subnetworks_only_ordered_jit[order].update(subnet_sets)
                     for subn_tw, subnetwork in subnet_sets.items():
-                        subnetworks[subn_tw] = {k: intw[k] for k in subnetwork["reachable_nodes"]}   #i think we can use rconn here instead of intw to save memory
-                        rconn_subn = subnetworks[subn_tw]  # this is the same as rconn_subn, but saves memory
+                        subnetworks[subn_tw] = {k: intw[k] for k in subnetwork["reachable_nodes"]}   
                         
                         if not waterbodies_df.empty and not usgs_df.empty:
                             path_func = partial(
@@ -616,9 +614,8 @@ def compute_nhd_routing_v02(
                 for twi, (subn_tw, subn_reach_list) in enumerate(
                     reaches_ordered_bysubntw[order].items(), 1
                 ):
-                    segs = list(chain.from_iterable(subn_reach_list))     #the other way to achieve this would be to just subnetworks_only_ordered_jit[order][subn_tw]["reachable_nodes"]
+                    segs = list(chain.from_iterable(subn_reach_list))    
                     segs_len = len(segs)
-
                     # try to assign to best-fit cluster (with max remaining capacity)
                     if heap:
                         remaining_cap, cluster = heap[0]
@@ -634,10 +631,6 @@ def compute_nhd_routing_v02(
                             new_remaining = remaining_cap - segs_len
                             heapq.heapreplace(heap, (-new_remaining, cluster))
                             continue
-                        # else:
-                        #     # if it can't fit in the max_heap, just push the popped head back again
-                        #     #technically, you can add/create a new cluster, and add that associate cluster in the heap, but current logic works when the heap is empty
-                        #     heapq.heappush(heap, (-remaining_cap, cluster))
 
                     # create a cluster when no cluster can fit or initiate the heap when heap is empty
                     cluster = cluster_counter
@@ -651,7 +644,6 @@ def compute_nhd_routing_v02(
                         "connecting_nodes": list(subnetworks_only_ordered_jit[order][subn_tw]["connecting_nodes"])
                     }
                     heapq.heappush(heap, (-capacity, cluster))
-
             # save subnetworks_only_ordered_jit and reaches_ordered_bysubntw_clustered in a list
             # to be passed on to next loop. Create a deep copy of this list to prevent it from being
             # altered before being returned
@@ -664,20 +656,6 @@ def compute_nhd_routing_v02(
             LOG.info("JIT Preprocessing time %s seconds." % (time.time() - start_time))
             LOG.info("starting Parallel JIT calculation")
 
-            # # save the information of reaches_ordered_bysubntw_clustered into a csv file that has info of order, cluster, and number of segments
-            # with open("Optimized_Output/reaches_ordered_bysubntw_clustered" + "_" + str(bin_threshold) + "_" + str(subnetwork_target_size) + ".csv", "w", newline="") as csvfile:
-            #     fieldnames = ["order", "cluster", "num_segments"]
-            #     writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-
-            #     writer.writeheader()
-            #     for order, clusters in reaches_ordered_bysubntw_clustered.items():
-            #         for cluster, info in clusters.items():
-            #             writer.writerow({
-            #                 "order": order,
-            #                 "cluster": cluster,
-            #                 "num_segments": len(info["segs"])
-            #             })
-
         start_para_time = time.time()
         # if 1 == 1:
         with Parallel(n_jobs=cpu_pool, backend="loky") as parallel:
@@ -689,16 +667,14 @@ def compute_nhd_routing_v02(
                 for cluster, clustered_subns in reaches_ordered_bysubntw_clustered[
                     order
                 ].items():
-                    segs = list(chain.from_iterable(subn_reach_list))                                   
+                    segs = clustered_subns['segs']
                     offnetwork_upstreams = set(clustered_subns['connecting_nodes'])
                     segs.extend(offnetwork_upstreams)
                     
                     common_segs = list(param_df.index.intersection(segs))
                     wbodies_segs = set(segs).symmetric_difference(common_segs)
-                    
                     #Declare empty dataframe
                     waterbody_types_df_sub = pd.DataFrame()
-
                     if not waterbodies_df.empty:
                         lake_segs = list(waterbodies_df.index.intersection(segs))
                         waterbodies_df_sub = waterbodies_df.loc[

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -7,7 +7,6 @@ import time
 import pandas as pd
 import numpy as np
 import copy
-import os.path
 
 import troute.nhd_network as nhd_network
 from troute.routing.fast_reach.mc_reach import compute_network_structured

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -571,7 +571,7 @@ def compute_nhd_routing_v02(
                 for order, subnet_sets in ordered_network.items():
                     subnetworks_only_ordered_jit[order].update(subnet_sets)
                     for subn_tw, subnetwork in subnet_sets.items():
-                        subnetworks[subn_tw] = {k: intw[k] for k in subnetwork}   #i think we can use rconn here instead of intw to save memory
+                        subnetworks[subn_tw] = {k: intw[k] for k in subnetwork["reachable_nodes"]}   #i think we can use rconn here instead of intw to save memory
                         rconn_subn = subnetworks[subn_tw]  # this is the same as rconn_subn, but saves memory
                         
                         if not waterbodies_df.empty and not usgs_df.empty:
@@ -616,7 +616,7 @@ def compute_nhd_routing_v02(
                 for twi, (subn_tw, subn_reach_list) in enumerate(
                     reaches_ordered_bysubntw[order].items(), 1
                 ):
-                    segs = list(chain.from_iterable(subn_reach_list))
+                    segs = list(chain.from_iterable(subn_reach_list))     #the other way to achieve this would be to just subnetworks_only_ordered_jit[order][subn_tw]["reachable_nodes"]
                     segs_len = len(segs)
 
                     # try to assign to best-fit cluster (with max remaining capacity)
@@ -629,6 +629,7 @@ def compute_nhd_routing_v02(
                             c["upstreams"].update(subnetworks[subn_tw])
                             c["tw"].append(subn_tw)
                             c["subn_reach_list"].extend(subn_reach_list)
+                            c["connecting_nodes"].extend(list(subnetworks_only_ordered_jit[order][subn_tw]["connecting_nodes"]))
 
                             new_remaining = remaining_cap - segs_len
                             heapq.heapreplace(heap, (-new_remaining, cluster))
@@ -647,6 +648,7 @@ def compute_nhd_routing_v02(
                         "upstreams": dict(subnetworks[subn_tw]),
                         "tw": [subn_tw],
                         "subn_reach_list": list(subn_reach_list),
+                        "connecting_nodes": list(subnetworks_only_ordered_jit[order][subn_tw]["connecting_nodes"])
                     }
                     heapq.heappush(heap, (-capacity, cluster))
 
@@ -691,14 +693,24 @@ def compute_nhd_routing_v02(
                     order
                 ].items():
                     segs = clustered_subns["segs"]
-                    offnetwork_upstreams = set()
-                    segs_set = set(segs)
-                    for seg in segs:
-                        for us in rconn[seg]:
-                            if us not in segs_set:
-                                offnetwork_upstreams.add(us)
-
+                    
+                    # offnetwork_upstreams = set()
+                    # for_loop_start_time = time.time()
+                    # segs_set = set(segs)
+                    # for seg in segs:
+                    #     for us in rconn[seg]:
+                    #         if us not in segs_set:
+                    #             offnetwork_upstreams.add(us)
+                    # for_loop_end_time = time.time()
+                    # for_loop_time += (for_loop_end_time - for_loop_start_time) 
+        
+                    # segs.extend(offnetwork_upstreams)                                        
+                    offnetwork_upstreams = set(clustered_subns['connecting_nodes'])
                     segs.extend(offnetwork_upstreams)
+
+
+                    
+                
                     
 
                     

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -15,6 +15,11 @@ import troute.routing.diffusive_utils_v02 as diff_utils
 from troute.routing.fast_reach import diffusive
 
 import logging
+import csv
+import heapq
+import pdb
+
+'''This is the newest version of the compute.py file, which is used to compute the routing for the NHD network.'''
 
 LOG = logging.getLogger('')
 
@@ -544,6 +549,7 @@ def compute_nhd_routing_v02(
     from_files = True,
     giuh_node = False,
 ):
+
     da_decay_coefficient = da_parameter_dict.get("da_decay_coefficient", 0)
     param_df["dt"] = dt
     param_df = param_df.astype("float32")
@@ -559,106 +565,120 @@ def compute_nhd_routing_v02(
             )
             subnetworks_only_ordered_jit = defaultdict(dict)
             subnetworks = defaultdict(dict)
+            reaches_ordered_bysubntw = defaultdict(dict)
             for tw, ordered_network in networks_with_subnetworks_ordered_jit.items():
                 intw = independent_networks[tw]
                 for order, subnet_sets in ordered_network.items():
                     subnetworks_only_ordered_jit[order].update(subnet_sets)
                     for subn_tw, subnetwork in subnet_sets.items():
-                        subnetworks[subn_tw] = {k: intw[k] for k in subnetwork}
+                        subnetworks[subn_tw] = {k: intw[k] for k in subnetwork}   #i think we can use rconn here instead of intw to save memory
+                        rconn_subn = subnetworks[subn_tw]  # this is the same as rconn_subn, but saves memory
+                        
+                        if not waterbodies_df.empty and not usgs_df.empty:
+                            path_func = partial(
+                                nhd_network.split_at_gages_waterbodies_and_junctions,
+                                set(usgs_df.index.values),
+                                set(waterbodies_df.index.values),
+                                subnetworks[subn_tw]
+                                )
+
+                        elif waterbodies_df.empty and not usgs_df.empty:
+                            path_func = partial(
+                                nhd_network.split_at_gages_and_junctions,
+                                set(usgs_df.index.values),
+                                subnetworks[subn_tw]
+                                )
+
+                        elif not waterbodies_df.empty and usgs_df.empty:
+                            path_func = partial(
+                                nhd_network.split_at_waterbodies_and_junctions,
+                                set(waterbodies_df.index.values),
+                                subnetworks[subn_tw]
+                                )
+
+                        else:
+                            path_func = partial(nhd_network.split_at_junction, subnetworks[subn_tw])
+
+                        reaches_ordered_bysubntw[order][
+                            subn_tw
+                        ] = nhd_network.dfs_decomposition(subnetworks[subn_tw], path_func)
             
-            reaches_ordered_bysubntw = defaultdict(dict)
-            for order, ordered_subn_dict in subnetworks_only_ordered_jit.items():
-                for subn_tw, subnet in ordered_subn_dict.items():
-                    conn_subn = {k: connections[k] for k in subnet if k in connections}
-                    rconn_subn = {k: rconn[k] for k in subnet if k in rconn}
-                    
-                    if not waterbodies_df.empty and not usgs_df.empty:
-                        path_func = partial(
-                            nhd_network.split_at_gages_waterbodies_and_junctions,
-                            set(usgs_df.index.values),
-                            set(waterbodies_df.index.values),
-                            rconn_subn
-                            )
 
-                    elif waterbodies_df.empty and not usgs_df.empty:
-                        path_func = partial(
-                            nhd_network.split_at_gages_and_junctions,
-                            set(usgs_df.index.values),
-                            rconn_subn
-                            )
-
-                    elif not waterbodies_df.empty and usgs_df.empty:
-                        path_func = partial(
-                            nhd_network.split_at_waterbodies_and_junctions,
-                            set(waterbodies_df.index.values),
-                            rconn_subn
-                            )
-
-                    else:
-                        path_func = partial(nhd_network.split_at_junction, rconn_subn)
-
-                    reaches_ordered_bysubntw[order][
-                        subn_tw
-                    ] = nhd_network.dfs_decomposition(rconn_subn, path_func)
-
-            cluster_threshold = 0.65  # When a job has a total segment count 65% of the target size, compute it
-            # Otherwise, keep adding reaches.
-
+            bin_threshold = 1.1  
             reaches_ordered_bysubntw_clustered = defaultdict(dict)
-
             for order in subnetworks_only_ordered_jit:
-                cluster = 0
-                reaches_ordered_bysubntw_clustered[order][cluster] = {
-                    "segs": [],
-                    "upstreams": {},
-                    "tw": [],
-                    "subn_reach_list": [],
-                }
+            # storing -capcaity as python only has min_heap and we want max_heap
+                heap = []
+                reaches_ordered_bysubntw_clustered[order] = defaultdict(dict)
+
+                cluster_counter = 0
+
                 for twi, (subn_tw, subn_reach_list) in enumerate(
                     reaches_ordered_bysubntw[order].items(), 1
                 ):
                     segs = list(chain.from_iterable(subn_reach_list))
-                    reaches_ordered_bysubntw_clustered[order][cluster]["segs"].extend(segs)
-                    reaches_ordered_bysubntw_clustered[order][cluster]["upstreams"].update(
-                        subnetworks[subn_tw]
-                    )
+                    segs_len = len(segs)
 
-                    reaches_ordered_bysubntw_clustered[order][cluster]["tw"].append(subn_tw)
-                    reaches_ordered_bysubntw_clustered[order][cluster][
-                        "subn_reach_list"
-                    ].extend(subn_reach_list)
+                    # try to assign to best-fit cluster (with max remaining capacity)
+                    if heap:
+                        remaining_cap, cluster = heap[0]
+                        remaining_cap = -remaining_cap  # restore positive capacity
+                        if segs_len <= remaining_cap:
+                            c = reaches_ordered_bysubntw_clustered[order][cluster]
+                            c["segs"].extend(segs)
+                            c["upstreams"].update(subnetworks[subn_tw])
+                            c["tw"].append(subn_tw)
+                            c["subn_reach_list"].extend(subn_reach_list)
 
-                    if (
-                        len(reaches_ordered_bysubntw_clustered[order][cluster]["segs"])
-                        >= cluster_threshold * subnetwork_target_size
-                    ) and (
-                        twi
-                        < len(reaches_ordered_bysubntw[order])
-                        # i.e., we haven't reached the end
-                        # TODO: perhaps this should be a while condition...
-                    ):
-                        cluster += 1
-                        reaches_ordered_bysubntw_clustered[order][cluster] = {
-                            "segs": [],
-                            "upstreams": {},
-                            "tw": [],
-                            "subn_reach_list": [],
-                        }
-            
+                            new_remaining = remaining_cap - segs_len
+                            heapq.heapreplace(heap, (-new_remaining, cluster))
+                            continue
+                        # else:
+                        #     # if it can't fit in the max_heap, just push the popped head back again
+                        #     #technically, you can add/create a new cluster, and add that associate cluster in the heap, but current logic works when the heap is empty
+                        #     heapq.heappush(heap, (-remaining_cap, cluster))
+
+                    # create a cluster when no cluster can fit or initiate the heap when heap is empty
+                    cluster = cluster_counter
+                    cluster_counter += 1
+                    capacity = (bin_threshold * subnetwork_target_size) - segs_len
+                    reaches_ordered_bysubntw_clustered[order][cluster] = {
+                        "segs": segs.copy(),
+                        "upstreams": dict(subnetworks[subn_tw]),
+                        "tw": [subn_tw],
+                        "subn_reach_list": list(subn_reach_list),
+                    }
+                    heapq.heappush(heap, (-capacity, cluster))
 
             # save subnetworks_only_ordered_jit and reaches_ordered_bysubntw_clustered in a list
             # to be passed on to next loop. Create a deep copy of this list to prevent it from being
             # altered before being returned
             subnetwork_list = [subnetworks_only_ordered_jit, reaches_ordered_bysubntw_clustered]
             subnetwork_list = copy.deepcopy(subnetwork_list)
-
         else:
             subnetworks_only_ordered_jit, reaches_ordered_bysubntw_clustered = copy.deepcopy(subnetwork_list)
         
         if 1 == 1:
             LOG.info("JIT Preprocessing time %s seconds." % (time.time() - start_time))
             LOG.info("starting Parallel JIT calculation")
+
         
+            
+        #     # save the information of reaches_ordered_bysubntw_clustered into a csv file that has info of order, cluster, and number of segments
+        #     with open("Optimized_Output/reaches_ordered_bysubntw_clustered" + "_" + str(bin_threshold) + "_" + str(subnetwork_target_size) + ".csv", "w", newline="") as csvfile:
+        #         fieldnames = ["order", "cluster", "num_segments"]
+        #         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+
+        #         writer.writeheader()
+        #         for order, clusters in reaches_ordered_bysubntw_clustered.items():
+        #             for cluster, info in clusters.items():
+        #                 writer.writerow({
+        #                     "order": order,
+        #                     "cluster": cluster,
+        #                     "num_segments": len(info["segs"])
+        #                 })
+        
+
         start_para_time = time.time()
         # if 1 == 1:
         with Parallel(n_jobs=cpu_pool, backend="loky") as parallel:
@@ -679,6 +699,8 @@ def compute_nhd_routing_v02(
                                 offnetwork_upstreams.add(us)
 
                     segs.extend(offnetwork_upstreams)
+                    
+
                     
                     common_segs = list(param_df.index.intersection(segs))
                     wbodies_segs = set(segs).symmetric_difference(common_segs)
@@ -875,7 +897,7 @@ def compute_nhd_routing_v02(
                             assume_short_ts,
                             return_courant,
                             from_files = from_files,
-                            giuh_node=giuh_node
+                            giuh_node = giuh_node
                         )
                     )
                 results_subn[order] = parallel(jobs)
@@ -1180,7 +1202,6 @@ def compute_nhd_routing_v02(
                             assume_short_ts,
                             return_courant,
                             from_files=from_files,
-                            giuh_node=giuh_node
                         )
                     )
 
@@ -1391,7 +1412,6 @@ def compute_nhd_routing_v02(
                         assume_short_ts,
                         return_courant,
                         from_files=from_files,
-                        giuh_node=giuh_node
                     )
                 )
 
@@ -1576,7 +1596,6 @@ def compute_nhd_routing_v02(
                     assume_short_ts,
                     return_courant,
                     from_files=from_files,
-                    giuh_node=giuh_node
                 )
             )
 
@@ -1736,10 +1755,10 @@ def compute_nhd_routing_v02(
                     },
                     assume_short_ts,
                     return_courant,
-                    giuh_node=giuh_node
                 )
             )
-
+    end_time = time.time()
+    print(f"ELAPSED TIME IN COMPUTE_NHD_ROUTING_FUNCTION: {end_time - start_time} seconds")
     return results, subnetwork_list
 
 def compute_diffusive_routing(

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -17,8 +17,6 @@ import logging
 import heapq
 
 
-'''This is the newest version of the compute.py file, which is used to compute the routing for the NHD network.'''
-
 LOG = logging.getLogger('')
 
 _compute_func_map = defaultdict(
@@ -1158,6 +1156,7 @@ def compute_nhd_routing_v02(
                             assume_short_ts,
                             return_courant,
                             from_files=from_files,
+                            giuh_node=giuh_node
                         )
                     )
 
@@ -1368,6 +1367,7 @@ def compute_nhd_routing_v02(
                         assume_short_ts,
                         return_courant,
                         from_files=from_files,
+                        giuh_node=giuh_node
                     )
                 )
 
@@ -1552,6 +1552,7 @@ def compute_nhd_routing_v02(
                     assume_short_ts,
                     return_courant,
                     from_files=from_files,
+                    giuh_node=giuh_node
                 )
             )
 
@@ -1711,10 +1712,10 @@ def compute_nhd_routing_v02(
                     },
                     assume_short_ts,
                     return_courant,
+                    giuh_node=giuh_node
                 )
             )
-    end_time = time.time()
-    print(f"ELAPSED TIME IN COMPUTE_NHD_ROUTING_FUNCTION: {end_time - start_time} seconds")
+
     return results, subnetwork_list
 
 def compute_diffusive_routing(

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -666,19 +666,19 @@ def compute_nhd_routing_v02(
 
         
             
-        #     # save the information of reaches_ordered_bysubntw_clustered into a csv file that has info of order, cluster, and number of segments
-        #     with open("Optimized_Output/reaches_ordered_bysubntw_clustered" + "_" + str(bin_threshold) + "_" + str(subnetwork_target_size) + ".csv", "w", newline="") as csvfile:
-        #         fieldnames = ["order", "cluster", "num_segments"]
-        #         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            # save the information of reaches_ordered_bysubntw_clustered into a csv file that has info of order, cluster, and number of segments
+            with open("Optimized_Output/reaches_ordered_bysubntw_clustered" + "_" + str(bin_threshold) + "_" + str(subnetwork_target_size) + ".csv", "w", newline="") as csvfile:
+                fieldnames = ["order", "cluster", "num_segments"]
+                writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
 
-        #         writer.writeheader()
-        #         for order, clusters in reaches_ordered_bysubntw_clustered.items():
-        #             for cluster, info in clusters.items():
-        #                 writer.writerow({
-        #                     "order": order,
-        #                     "cluster": cluster,
-        #                     "num_segments": len(info["segs"])
-        #                 })
+                writer.writeheader()
+                for order, clusters in reaches_ordered_bysubntw_clustered.items():
+                    for cluster, info in clusters.items():
+                        writer.writerow({
+                            "order": order,
+                            "cluster": cluster,
+                            "num_segments": len(info["segs"])
+                        })
         
 
         start_para_time = time.time()


### PR DESCRIPTION
I have added a new algorithm, bin packing with max heap, to distribute the number of subnetworks to a cluster that results in even cluster distribution with almost equal segments/reaches. Empirically, I have found that ideal target size for doing the Mississippi run (which is the bottle neck run if distributed by HUCs) should be 1000. With the target size of 1000 and the the new code, the routing computation has significantly improved nearly 45% in comparison to 10,000 (previously thought ideal size). 

Why previous algorithm failed to create equal cluster size? 
In previous algorithm, a cluster gets created. And it keeps on adding subnetworks to that cluster until the the sum of segments of all subnetworks present in that cluster is greater than 0.65 * target_size (this is called cluster threshold). And after it is greater than cluster threshold, a new cluster gets created and it repeats the same process. It doesn't keep track of previous cluster created and what size it has. This can lead to creating overflow of number of segments in a cluster and also create an underflow. 

Overflow case
Let's imagine the target size is 1000. And three subnetworks are to be added s1 = 300, s2 = 340, s3 = 1400, s4 = 300. So, the threshold is 650. It adds s1 and s2 to the first cluster, and the total sum is 640. Since it has still not hit the threshold, it will add s3 to the same cluster and the total size of the first cluster is 2040. And a new cluster will be created for s4 wityh size 300. The idea is to make the cluster size close to the cluster_threshold. This will only, partially, guarantee that the cluster size is not less than the cluster threshold. Now, we have 2 clusters with size 2040 and 300

Underflow case
Let's imagine the target size is 1000. And there are two clusters already created ( C1 = 680 and C2 = 800). But now, we need to add a very small subnetwork with size 50. Since, each cluster has already hit the cluster threshold, a new cluster C3 will be created just for that subnetwork. And if this is the last subnetwork in that order (or the very last ones where each one of them is of not a big size), it will create a scenario of an underflow.




The root cause of this issue is that there is no upper limit of how big a cluster can be. It only tries to ensure that it's not less than 0.65 * threshold. And even if an upper limit is set, there should be a check of what the remaining size of cluster is when adding new subnetwork.




The bin packing algorithm does that. It sets the upper limit of the cluster size to be 1.1 * target size. And it keeps track of the remaining size of each cluster, and has an instant access of cluster that has highest remaining size. So, that if the subnetwork doesn't fit the cluster with the highest remaining size it creates a new cluster. This helps in making the cluster size as similar as possible. 

Let's see how it tackles those two cases:

Overflow case:
It adds s1 and s2 to the first cluster and the total sum is 640. Since the remaining size is smaller than the size of s3, it goes ahead and makes a new cluster for s3 with size 1400. And since the first cluster has remaining size of 460, it can add s4 to the first cluster. Therefor we will have two clusters with size 940 and 1400 instead of 2040 and 300.

Underflow case:
It will simply add that subnetwork to C1 (as it has maximum remaining size), instead of creating a new cluster and avoid that underflow case. 



I have attached a picture that demonstrates the cluster distribution with the new code and the old one. 


<img width="1412" height="502" alt="Screenshot 2025-09-18 at 2 40 10 PM" src="https://github.com/user-attachments/assets/451aca21-6235-4288-ad83-992423acad0f" />
