### PR TITLE
use qlat_file_value_col to read ngen cat-* files

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -766,13 +766,21 @@ class HYFeaturesNetwork(AbstractNetwork):
                         for id, area in results:
                             areas[id] = area
                             
-                qlat_column = self.forcing_parameters.get("qlat_file_value_col", None)                   
-                    
+                qlat_column = self.forcing_parameters.get("qlat_file_value_col", None)
+
+                if qlat_file_pattern_filter == "cat-*":
+                    if qlat_column not in pd.read_csv(qlat_files[0], nrows=0).columns:
+                        raise RuntimeError(
+                            "When using qlat_file_pattern_filter as 'cat-*', qlat_file_value_col must be properly specified in the yaml file. "
+                            f"Either qlat_file_value_col is not specified and defaulted to '{qlat_column}' or the specified qlat_file_value_col does not exist in the column of "
+                            "lateral flow files."
+                        )
+
                 def process_file(f):
                     f = Path(f)
                     if qlat_file_pattern_filter=="nex-*":
                         df = pd.read_csv(f, names=['timestamp', 'qlat'], index_col=[0])
-                    else:                        
+                    else:              
                         df = pd.read_csv(f,usecols= ['Time', qlat_column])
                         df.rename(columns={'Time': 'timestamp', qlat_column: 'qlat'}, inplace=True)
                         cat_id = f.stem

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -766,12 +766,7 @@ class HYFeaturesNetwork(AbstractNetwork):
                         for id, area in results:
                             areas[id] = area
                             
-                qlat_column = self.forcing_parameters.get("qlat_file_value_col", None)
-                # the code in this if statement is very nextgen specific so change the default here
-                # rather than the default in config module for better compatibility
-                if qlat_column is None or qlat_column == "q_lateral":
-                    qlat_column = "Q_OUT"
-                    
+                qlat_column = self.forcing_parameters.get("qlat_file_value_col", None)                   
                     
                 def process_file(f):
                     f = Path(f)

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -765,14 +765,21 @@ class HYFeaturesNetwork(AbstractNetwork):
                         areas = {}
                         for id, area in results:
                             areas[id] = area
+                            
+                qlat_column = self.forcing_parameters.get("qlat_file_value_col", None)
+                # the code in this if statement is very nextgen specific so change the default here
+                # rather than the default in config module for better compatibility
+                if qlat_column is None or qlat_column == "q_lateral":
+                    qlat_column = "Q_OUT"
+                    
                     
                 def process_file(f):
                     f = Path(f)
                     if qlat_file_pattern_filter=="nex-*":
                         df = pd.read_csv(f, names=['timestamp', 'qlat'], index_col=[0])
                     else:                        
-                        df = pd.read_csv(f,usecols= ['Time', 'Q_OUT'])
-                        df.rename(columns={'Time': 'timestamp', 'Q_OUT': 'qlat'}, inplace=True)
+                        df = pd.read_csv(f,usecols= ['Time', qlat_column])
+                        df.rename(columns={'Time': 'timestamp', qlat_column: 'qlat'}, inplace=True)
                         cat_id = f.stem
                         area = areas[cat_id]
                         # https://github.com/CIROH-UA/ngen/blob/77d8ea28502bf8db771529c5852d273785e26554/include/core/Layer.hpp#L142


### PR DESCRIPTION
When we added the ability to read from cat-* files, it was hardcoded to look for col "Q_OUT" which is only used by cfe. 
This change allows you to use the existing `qlat_file_value_col` config parameter to set this to something different.

The preprocessor still only generates config with "nex-*" in it so this will only break configs for the few people who've changed the default value to cat-* after we added it.

using the lstm which has no Q_OUT column gives the error below which was fixed by adding 
<img width="688" height="198" alt="image" src="https://github.com/user-attachments/assets/157cf664-c7d3-4444-b80d-552dca8725cd" />


<img width="1344" height="772" alt="image" src="https://github.com/user-attachments/assets/8ba0c20c-6a7f-498a-a6bc-7c5f6f5adf36" />


