### PR TITLE
delete csv folder instead of using wildcards

### DIFF
--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -962,7 +962,8 @@ def split_csv_file(nexus_file, binary_folder):
 def rewrite_to_parquet(file_args, binary_folder):
     tempfile_id, output_file_id = file_args
     # Rewrite the csv file to parquet
-    df = pd.read_csv(f'{binary_folder}/tempfile_{tempfile_id}.csv', names=['feature_id', output_file_id])
+    csv_binary_folder = os.path.join(binary_folder, 'csv_temp')
+    df = pd.read_csv(f'{csv_binary_folder}/tempfile_{tempfile_id}.csv', names=['feature_id', output_file_id])
     df.set_index('feature_id', inplace=True)  # Set feature_id as the index
     df[output_file_id] = df[output_file_id].astype(float)  # Convert output_file_id column to float64
     table_new = pa.Table.from_pandas(df)
@@ -972,7 +973,10 @@ def rewrite_to_parquet(file_args, binary_folder):
 def nex_files_to_binary(nexus_files, binary_folder):
     # Get the output files
     output_timesteps = get_timesteps_from_nex(nexus_files)
-    partial_split_csv_file = partial(split_csv_file, binary_folder=binary_folder)
+    csv_binary_folder = os.path.join(binary_folder, 'csv_temp') # so that we don't have to rm -rf using bash wildcards
+    partial_split_csv_file = partial(split_csv_file, binary_folder=csv_binary_folder)
+    if not os.path.exists(csv_binary_folder):
+        os.system(f'mkdir {csv_binary_folder}')
     # Split the csv file into multiple csv files
     with multiprocessing.Pool() as pool:
         pool.map(partial_split_csv_file, nexus_files)
@@ -987,7 +991,7 @@ def nex_files_to_binary(nexus_files, binary_folder):
 
     
     # Clean up the temp files
-    os.system(f'rm -rf {binary_folder}/tempfile_*.csv')
+    os.system(f'rm -rf {csv_binary_folder}')
     
     nexus_input_folder = binary_folder
     forcing_glob_filter = '*NEXOUT.parquet'


### PR DESCRIPTION
Identified in https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/358 by @lou-a

The NGIAB data preprocessor automatically generates t-route realization files that turn on binary nexus parquet files if it calculates that one's system memory is below a certain limit so that it doesn't have to load in all of the nexus input files at once. The original t-route code then deletes temporary binary csv files using `rm -rf {binary_folder}/tempfile_*.csv`, but depending on the memory availability of your machine, this can cause the "too many arguments" error. (Example: in the issue, > 100000 of these csv files were generated).

This fix circumvents using a wildcard-based argument and just passes an entire temporary folder to the `rm -rf ` command.