### PR TITLE
futureproofed DA module

### DIFF
--- a/src/troute-network/troute/DataAssimilation.py
+++ b/src/troute-network/troute/DataAssimilation.py
@@ -1541,7 +1541,7 @@ def new_lastobs(run_results, time_increment):
                 np.array([rr[3][1],rr[3][2]]).T,
                 index=rr[3][0],
                 columns=["time_since_lastobs", "lastobs_discharge"]
-            )
+            ).astype({"time_since_lastobs": np.float32, "lastobs_discharge": np.float32})
             for rr in run_results
         ],
         copy=False,
@@ -1919,11 +1919,11 @@ def _read_timeseries_files(filepath, timeseries_dates, t0, final_persist_datetim
     file_list = (df['Datetime'] + '.60min.' + df['ID'] + '.RFCTimeSeries.ncdf').tolist()
     rfc_df = pd.DataFrame()
     for f in file_list:
-        ds = xr.open_dataset(filepath + '/' + f)
+        ds = xr.open_dataset(filepath + '/' + f, decode_timedelta=True)
         sliceStartTime = datetime.strptime(ds.attrs.get('sliceStartTimeUTC'), '%Y-%m-%d_%H:%M:%S')
         sliceTimeResolutionMinutes = ds.attrs.get('sliceTimeResolutionMinutes')
         df = ds.to_dataframe().reset_index().sort_values('forecastInd')[['stationId','discharges','synthetic_values','totalCounts','timeSteps']]
-        df['Datetime'] = pd.date_range(sliceStartTime, periods=df.shape[0], freq=sliceTimeResolutionMinutes+'T')
+        df['Datetime'] = pd.date_range(sliceStartTime, periods=df.shape[0], freq=sliceTimeResolutionMinutes+'min')
         # Filter out forecasts that go beyond the rfc_persist_days parameter. This isn't necessary, but removes
         # excess data, keeping the dataframe of observations as small as possible.
         df = df[df['Datetime']<final_persist_datetime]
@@ -1979,9 +1979,9 @@ def assemble_rfc_dataframes(rfc_timeseries_df, rfc_lake_gage_crosswalk, t0, rfc_
     reservoir_rfc_param_df['totalCounts'] = reservoir_rfc_param_df['totalCounts'] + (new_timeseries_idx - reservoir_rfc_param_df['timeseries_idx'])
     reservoir_rfc_param_df['timeseries_idx'] = new_timeseries_idx
     # Fill in NaNs with default values.
-    reservoir_rfc_param_df['use_rfc'].fillna(False, inplace=True)
-    reservoir_rfc_param_df['totalCounts'].fillna(0, inplace=True)
-    reservoir_rfc_param_df['da_timestep'].fillna(0, inplace=True)
+    reservoir_rfc_param_df['use_rfc'] = reservoir_rfc_param_df['use_rfc'].fillna(False)
+    reservoir_rfc_param_df['totalCounts'] = reservoir_rfc_param_df['totalCounts'].fillna(0)
+    reservoir_rfc_param_df['da_timestep'] = reservoir_rfc_param_df['da_timestep'].fillna(0)
     # Make sure columns are the correct types
     reservoir_rfc_param_df['totalCounts'] = reservoir_rfc_param_df['totalCounts'].astype(int)
     reservoir_rfc_param_df['da_timestep'] = reservoir_rfc_param_df['da_timestep'].astype(int)


### PR DESCRIPTION
## Summary
the verbosity of the outputs was getting unusable, especially with batch runs, so I mitigated this by just fixing some of the issues causing `FutureWarning`s

---

## Changes
* explicitly set dtype of columns

* changed inplace method to preferred `df['col'] = df['col'].method(value)` syntax

* futureproofed xarray and pandas datetime handling

## Testing
Testing and validating was done by running `test/LowerColorado_TX_v4/test_AnA_V4_HYFeature` before and after the change and making sure the output values were still the same

1.
```
FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation. df = pd.concat(
```
This warning still shows up, but I handled the behavior it's warning about by explicitly setting the `dtype` of the columns.

2.
```
FutureWarning: 'T' is deprecated and will be removed in a future version, please use 'min' instead.
```
and 
```
FutureWarning: In a future version, xarray will not decode timedelta values based on the presence of a timedelta-like units attribute by default. Instead it will rely on the presence of a timedelta64 dtype attribute, which is now xarray's default way of encoding timedelta64 values. To continue decoding timedeltas based on the presence of a timedelta-like units attribute, users will need to explicitly opt-in by passing True or CFTimedeltaCoder(decode_via_units=True) to decode_timedelta. To silence this warning, set decode_timedelta to True, False, or a 'CFTimedeltaCoder' instance.
```
handled according to the instructions in the warning

3. 
```FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.
The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.

For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.
```
handled according to the instructions in the warning