### PR TITLE
fix input data day offset

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -739,6 +739,8 @@ class HYFeaturesNetwork(AbstractNetwork):
         nts = run.get("nts", 1)
         qlat_input_folder = run.get("qlat_input_folder", None)
         qlat_input_file = run.get("qlat_input_file", None)
+        max_col = 1 + nts // qts_subdivisions
+        col_t0 =self.t0.strftime('%Y%m%d%H%M')
 
         if qlat_input_folder:
             qlat_input_folder = Path(qlat_input_folder)
@@ -794,6 +796,20 @@ class HYFeaturesNetwork(AbstractNetwork):
                     df.index = [int("".join(filter(str.isdigit, f.stem)))]
                     df = df.rename_axis(None, axis=1)
                     df.index.name = 'feature_id'
+                    try:
+                        col_t0_idx = df.columns.get_loc(col_t0)
+                    except KeyError:
+                        raise ValueError(f'Datetime column "{col_t0}" does not exist in nex-* files.')
+
+                    stop = col_t0_idx + max_col - 1
+                    # Check bounds for stop index
+                    if stop > len(df.columns):
+                        raise ValueError(
+                            f"The expected range of datetime columns does not exist in the nex-* files. "
+                            f"Requested columns from index {col_t0_idx} to {stop - 1}, "
+                            f"but dataframe only has {len(df.columns)} columns total."
+                        )
+                    df = df.iloc[:, col_t0_idx:stop]
                     return df
 
                 with Parallel(n_jobs=-1) as p:


### PR DESCRIPTION
> Summary
> 
> This PR fixes an issue with processing lateral flow input files when the file pattern was "nex-_" or "cat-_".
> 
> Problem
> 
> Previously, the start-time parameter — which defines the beginning of the data simulation — was not being properly applied when reading "nex-_" or "cat-_" input files. As a result, the simulation ran over an incorrect time window.
> 
> For example: If the lateral flow input covers 2023-04-01 to 2023-04-03, nts = 24, and the start time is 2023-04-02_00:00, the simulation should run from 2023-04-02_00:00 to 2023-04-02_23:00. However, the previous implementation simulated from 2023-04-01_00:00 to 2023-04-02_00:23, which was incorrect.
> 
> Fix
> 
> The updated logic now correctly accounts for the specified start time when reading "nex-_" or "cat-_" files, ensuring that the simulation window aligns with the intended period.
> 
> I used a tool to make the code pythonic and it looks like that changed the code heavily. But the real change is in build_qlateral_array() function. Everything else is just formatting related change, which can be completely ignored.

copied from #40 with the formatting changes reverted and rebased to the most recent ngiab


Co-authored-by: Josh Cunningham <jcunningham8@ua.edu>
