### PR TITLE
add usgs da loading from feather

### DIFF
--- a/src/troute-config/troute/config/compute_parameters.py
+++ b/src/troute-config/troute/config/compute_parameters.py
@@ -269,6 +269,12 @@ class StreamflowDA(BaseModel):
     If True, enable streamflow data assimilation in diffusive module. 
     NOTE: Not yet implemented, leave as False. (June 25, 2024)
     """
+    da_from_feather: Optional[FilePath] = None
+    """
+    Path to a feather file containing streamflow data to use for DA.
+    This bypasses all the usual DA file reading logic via usgs_timeslices_folder and uses the feather file directly.
+    Setting this will turn on streamflow nudging regardless of it's value in the config.
+    """
 
 
 class ReservoirPersistenceDA(BaseModel):

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -194,6 +194,20 @@ def main_v04(argv):
     if (not kernelTalks):
         firstRun = False
 
+    streamflow_da = compute_parameters.get("data_assimilation_parameters",{}).get("streamflow_da",{})
+    usgs_da_file = streamflow_da.get("da_from_feather", None)
+    if usgs_da_file:
+        feather_file = Path(usgs_da_file)
+        if not feather_file.exists():
+            print(f"Warning: feather file {usgs_da_file} does not exist.")
+        else:
+            try:
+                data_assimilation.usgs_df = pd.read_feather(feather_file)
+                streamflow_da["streamflow_nudging"] = True
+            except Exception as e:
+                print(f"Error reading feather file {usgs_da_file}: {e}")
+        
+
     for run_set_iterator, run in enumerate(run_sets):
         
         t0 = run.get("t0")


### PR DESCRIPTION
Adds the option to load the usgs data assimilation dataframe used for nudging straight from a feather file and bypass all of the usgs timeslice file reading and other complex file formatting.

use this utility https://github.com/AlabamaWaterInstitute/troute-usgsdf to create the dataframes

```bash 
uvx troute-usgsdf --ngiab-data-dir /path/to/ngiab/
```
or if you're not using nextgen in a box
```bash
uvx troute-usgsdf \
  --gpkg /path/to/domain.gpkg \
  --troute-config /path/to/troute.yaml \
  --output /path/to/troute_da.feather
```

